### PR TITLE
Update ioscross README build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,7 @@ osxcross:
 	$(MAKE) shell-osxcross SHELL_COMMAND='./platform/osxcross/build_debug.sh'
 
 docker-ioscross:
-	@echo ${IOSCROSS_PASSWORD} > secret
-	docker build --secret id=secret,src=secret -t godot-csound-ioscross ./platform/ioscross
-	@rm -rf secret
+	docker build -t godot-csound-ioscross ./platform/ioscross
 
 shell-ioscross: docker-ioscross
 	docker run -it --rm -v ${CURDIR}:${CURDIR} --user ${UID}:${GID} -w ${CURDIR} godot-csound-ioscross ${SHELL_COMMAND}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,15 @@ sudo usermod -a -G docker $USER
 git submodule update --init --recursive
 ```
 
-4. Build project using make:
+4. Download XCode 15.1 with the iOS SDK (you must be logged into an Apple ID to download Xcode).
+
+5. In the folder containing the Xcode_15.1.xip file start an HTTP server to host the file:
+
+```bash
+python -m http.server 8000
+```
+
+6. Build project using make:
 
 ```bash
 #build all platforms

--- a/platform/ioscross/Dockerfile
+++ b/platform/ioscross/Dockerfile
@@ -22,10 +22,16 @@ RUN apt install -y autoconf libtool \
     ninja-build
 
 ARG XCODE=Xcode_15.1.xip
-ARG DOWNLOAD_URL=http://172.17.0.1:8000/$XCODE.enc
+ARG DOWNLOAD_URL=http://172.17.0.1:8000/$XCODE
 
 WORKDIR /
-RUN --mount=type=secret,id=IOSCROSS_PASSWORD curl $DOWNLOAD_URL | openssl aes-256-cbc -pbkdf2 -d -a -pass pass:$(cat /run/secrets/IOSCROSS_PASSWORD) > $XCODE
+RUN --mount=type=secret,id=IOSCROSS_PASSWORD <<END
+if [ -f /run/secrets/IOSCROSS_PASSWORD ]; then
+    curl $DOWNLOAD_URL | openssl aes-256-cbc -pbkdf2 -d -a -pass pass:$(cat /run/secrets/IOSCROSS_PASSWORD) > $XCODE
+else
+    curl $DOWNLOAD_URL > $XCODE
+fi
+END
 
 RUN git clone https://github.com/mackyle/xar.git
 WORKDIR /xar


### PR DESCRIPTION
Update ioscross README build instructions and
also allow building locally without requiring a password

Fixes #40