### PR TITLE
Update to fix verifying windows build

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -124,6 +124,7 @@ jobs:
         with:
           path: addons/csound/bin
           key: windows-artifacts-${{github.run_id}}
+          enableCrossOsArchive: true
 
   macos-build:
     name: MacOS build
@@ -418,6 +419,9 @@ jobs:
     name: Verify Windows build
     runs-on: windows-latest
     needs: windows-build
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout source code
         uses: actions/checkout@v1
@@ -430,6 +434,7 @@ jobs:
         with:
           path: addons/csound/bin
           key: windows-artifacts-${{github.run_id}}
+          enableCrossOsArchive: true
 
       - name: Setup Godot
         uses: chickensoft-games/setup-godot@v1
@@ -440,9 +445,9 @@ jobs:
 
       - name: Verify godot-csound
         run: |
-          godot --headless --import
-          godot --headless --import
-          godot --headless -s csound_run_scene.gd
+          godot --headless --import || true
+          godot --headless --import || true
+          (godot --headless -s csound_run_scene.gd 2> NUL || true) | grep 'output result is 4'
 
   publish_artifacts:
     if: ${{ github.ref == 'refs/heads/main' }}
@@ -467,6 +472,7 @@ jobs:
         with:
           path: addons/csound/bin
           key: windows-artifacts-${{github.run_id}}
+          enableCrossOsArchive: true
 
       - name: Restore cached MacOS artifacts
         uses: actions/cache/restore@v4


### PR DESCRIPTION
Update windows build to use bash shell when verifying if godot-csound is working

fixes #31