### PR TITLE
Update build images workflow

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -18,11 +18,6 @@ jobs:
     env:
       VERSION: v1
     steps:
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          docker-images: false
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -49,11 +44,6 @@ jobs:
     env:
       VERSION: v1
     steps:
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          docker-images: false
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -80,11 +70,6 @@ jobs:
     env:
       VERSION: v1
     steps:
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          docker-images: false
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -111,11 +96,6 @@ jobs:
     env:
       VERSION: v1
     steps:
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          docker-images: false
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -142,11 +122,6 @@ jobs:
     env:
       VERSION: v1
     steps:
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          docker-images: false
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -173,11 +148,6 @@ jobs:
     env:
       VERSION: v1
     steps:
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          docker-images: false
-
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Making space for builds is not longer required now that the builds were moved to godot-build-containers