### PR TITLE
Remove deprecated Android architectures

### DIFF
--- a/platform/android/build_debug.sh
+++ b/platform/android/build_debug.sh
@@ -3,7 +3,7 @@
 dir=$(realpath .)
 src_dir=$dir/modules/csound
 
-for ARCH in arm arm64 x86 x64; do
+for ARCH in arm64 x64; do
     build_dir=$src_dir/build/android-$ARCH/debug
     prefix=$dir/addons/csound/bin/android-$ARCH/debug
 
@@ -26,14 +26,8 @@ done
 
 cd $dir
 
-scons -c platform=android arch=arm32 target=template_debug dev_build=yes debug_symbols=yes android_api_level=23
-scons platform=android arch=arm32 target=template_debug dev_build=yes debug_symbols=yes android_api_level=23
-
 scons -c platform=android arch=arm64 target=template_debug dev_build=yes debug_symbols=yes android_api_level=23
 scons platform=android arch=arm64 target=template_debug dev_build=yes debug_symbols=yes android_api_level=23
-
-scons -c platform=android arch=x86_32 target=template_debug dev_build=yes debug_symbols=yes android_api_level=23
-scons platform=android arch=x86_32 target=template_debug dev_build=yes debug_symbols=yes android_api_level=23
 
 scons -c platform=android arch=x86_64 target=template_debug dev_build=yes debug_symbols=yes android_api_level=23
 scons platform=android arch=x86_64 target=template_debug dev_build=yes debug_symbols=yes android_api_level=23

--- a/platform/android/build_release.sh
+++ b/platform/android/build_release.sh
@@ -3,7 +3,7 @@
 dir=$(realpath .)
 src_dir=$dir/modules/csound
 
-for ARCH in arm arm64 x86 x64; do
+for ARCH in arm64 x64; do
     build_dir=$src_dir/build/android-$ARCH/release
     prefix=$dir/addons/csound/bin/android-$ARCH/release
 
@@ -26,14 +26,8 @@ done
 
 cd $dir
 
-scons -c platform=android arch=arm32 target=template_release android_api_level=23
-scons platform=android arch=arm32 target=template_release android_api_level=23
-
 scons -c platform=android arch=arm64 target=template_release android_api_level=23
 scons platform=android arch=arm64 target=template_release android_api_level=23
-
-scons -c platform=android arch=x86_32 target=template_release android_api_level=23
-scons platform=android arch=x86_32 target=template_release android_api_level=23
 
 scons -c platform=android arch=x86_64 target=template_release android_api_level=23
 scons platform=android arch=x86_64 target=template_release android_api_level=23


### PR DESCRIPTION
Removing deprecated Android architectures in order to allow updating to the latest godot version (4.5)