### PR TITLE
Use release binaries for the editor

### DIFF
--- a/templates/csoundgodot.gdextension.in
+++ b/templates/csoundgodot.gdextension.in
@@ -9,14 +9,17 @@ compatibility_minimum = 4.5
 
 [libraries]
 
+macos.editor = "res://addons/csound/bin/macos/macos.framework/libcsoundgodot.macos.template_release"
 macos.debug = "res://addons/csound/bin/macos/macos.framework/libcsoundgodot.macos.template_debug"
 macos.release = "res://addons/csound/bin/macos/macos.framework/libcsoundgodot.macos.template_release"
 ios.debug.simulator = "res://addons/csound/bin/ios/libcsoundgodot.ios.template_debug.dev.universal.simulator.dylib"
 ios.release.simulator = "res://addons/csound/bin/ios/libcsoundgodot.ios.template_release.universal.simulator.dylib"
 ios.debug.arm64 = "res://addons/csound/bin/ios/libcsoundgodot.ios.template_debug.dev.arm64.dylib"
 ios.release.arm64 = "res://addons/csound/bin/ios/libcsoundgodot.ios.template_release.arm64.dylib"
+windows.editor.x86_64  =  "res://addons/csound/bin/windows/libcsoundgodot.windows.template_release.x86_64.dll"
 windows.debug.x86_64 = "res://addons/csound/bin/windows/libcsoundgodot.windows.template_debug.dev.x86_64.dll"
 windows.release.x86_64 = "res://addons/csound/bin/windows/libcsoundgodot.windows.template_release.x86_64.dll"
+linux.editor.x86_64  =  "res://addons/csound/bin/linux/libcsoundgodot.linux.template_release.x86_64.so"
 linux.debug.x86_64 = "res://addons/csound/bin/linux/libcsoundgodot.linux.template_debug.dev.x86_64.so"
 linux.release.x86_64 = "res://addons/csound/bin/linux/libcsoundgodot.linux.template_release.x86_64.so"
 web.release.wasm32 = "res://addons/csound/bin/web/libcsoundgodot.web.template_release.wasm32.wasm"
@@ -33,7 +36,7 @@ android.release.x86_64 = "res://addons/csound/bin/android/libcsoundgodot.android
 [dependencies]
 
 linux.editor.x86_64  = {
-"linux/debug/lib64/libcsound64.so.7.0": ""
+"linux/release/lib64/libcsound64.so.7.0": ""
 }
 linux.debug.x86_64  = {
 "linux/debug/lib64/libcsound64.so.7.0": ""
@@ -42,10 +45,10 @@ linux.release.x86_64 = {
 "linux/release/lib64/libcsound64.so.7.0": ""
 }
 windows.editor.x86_64  = {
-"windows/debug/lib/csound64.dll": "",
-"windows/debug/lib/libstdc++-6.dll": "",
-"windows/debug/lib/libgcc_s_seh-1.dll": "",
-"windows/debug/lib/libwinpthread-1.dll": ""
+"windows/release/lib/csound64.dll": "",
+"windows/release/lib/libstdc++-6.dll": "",
+"windows/release/lib/libgcc_s_seh-1.dll": "",
+"windows/release/lib/libwinpthread-1.dll": ""
 }
 windows.debug.x86_64  = {
 "windows/debug/lib/csound64.dll": "",
@@ -60,7 +63,7 @@ windows.release.x86_64 = {
 "windows/release/lib/libwinpthread-1.dll": ""
 }
 macos.editor = {
-"macos/debug/Library/Frameworks/CsoundLib64.framework": ""
+"macos/release/Library/Frameworks/CsoundLib64.framework": ""
 }
 macos.debug = {
 "macos/debug/Library/Frameworks/CsoundLib64.framework": ""


### PR DESCRIPTION
The debug version of godot-csound is running slower.  Use the release binaries for now.  Related #214